### PR TITLE
feat(server, logging, docker, ci): production-grade logging, low-memo…

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -72,3 +72,23 @@ jobs:
             VCS_REF=${{ github.sha }}
             VERSION=${{ steps.meta.outputs.version || '' }}
             REPO_URL=${{ github.server_url }}/${{ github.repository }}
+
+      - name: Build and push Docker image (low-memory)
+        if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
+        id: push_lowmem
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          push: true
+          tags: |
+            krzprzybyla/poker-planning:lowmem
+            krzprzybyla/poker-planning:${{ github.ref_name }}-lowmem
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            BUILD_DATE=
+            VCS_REF=${{ github.sha }}
+            VERSION=${{ steps.meta.outputs.version || '' }}
+            REPO_URL=${{ github.server_url }}/${{ github.repository }}
+            LOW_MEMORY=true

--- a/artillery-sio.yml
+++ b/artillery-sio.yml
@@ -1,0 +1,108 @@
+# Artillery v2 Socket.IO test for Planning Poker app
+# Target: production instance
+# Usage examples:
+#   - Participants only (join existing room):
+#       ROOM_ID=ABC123 artillery run artillery-sio.yml
+#   - Scrum master flow (creates rooms):
+#       artillery run --scenarios=scum_master_flow artillery-sio.yml
+#     (Uwaga: SM-flow nie dzieli roomId między VU, traktuj jako smoke test e2e.)
+
+config:
+  target: "http://localhost"
+
+  # Fazy obciążenia – dopasuj do potrzeb
+  phases:
+    - duration: 60   # rozgrzewka 1 min
+      arrivalRate: 5
+      name: warmup
+    - duration: 300  # 5 min narastania
+      arrivalRate: 20
+      rampTo: 100
+      name: ramp
+    - duration: 300  # 5 min stałego obciążenia
+      arrivalRate: 100
+      name: sustain
+
+  engines:
+    socketio: {}
+
+  socketio:
+    transports: ["websocket"]
+    path: "/socket.io"
+    # secure: true # wnioskowane z https targetu
+
+  ensure:
+    maxErrorRate: 1 # akceptuj do 1% błędów
+
+  variables:
+    # Ustaw przez środowisko: ROOM_ID=ABC123 artillery run artillery-sio.yml
+    ROOM_ID: "{{ $env.ROOM_ID || '' }}"
+
+scenarios:
+  # 1) Scenariusz Scrum Master – pełny przepływ e2e dla jednego klienta
+  - name: scrum_master_flow
+    weight: 0 # ustaw na >0 aby włączyć w tescie mieszanym
+    engine: "socketio"
+    flow:
+      - emit:
+          channel: "createRoom"
+          data:
+            userName: "SM-{{ $randomString() }}"
+            initialStory: null
+          acknowledge: true
+          capture:
+            - json: "$.roomId"
+              as: "roomId"
+            - json: "$.user.id"
+              as: "smUserId"
+      - think: 1
+      - emit:
+          channel: "startVoting"
+          data:
+            roomId: "{{ roomId }}"
+            story:
+              title: "Historia {{ $randomString() }}"
+              description: "Test load"
+      - think: 1
+      - emit:
+          channel: "submitVote"
+          data:
+            roomId: "{{ roomId }}"
+            userId: "{{ smUserId }}"
+            value: "5"
+      - think: 1
+      - emit:
+          channel: "revealResults"
+          data:
+            roomId: "{{ roomId }}"
+      - think: 1
+      - emit:
+          channel: "resetVoting"
+          data:
+            roomId: "{{ roomId }}"
+
+  # 2) Scenariusz Uczestnik – dołącz do podanego pokoju i oddaj głos
+  - name: participant_flow
+    weight: 1 # główny scenariusz do obciążenia – zwiększ jeśli używasz mieszanki
+    engine: "socketio"
+    flow:
+      # Uwaga: WYMAGANY ROOM_ID (np. ROOM_ID=ABC123)
+      - think: 0.5
+      - emit:
+          channel: "joinRoom"
+          data:
+            roomId: "{{ ROOM_ID }}"
+            userName: "U-{{ $randomString() }}"
+          acknowledge: true
+          capture:
+            - json: "$.user.id"
+              as: "userId"
+      - think: 1
+      - emit:
+          channel: "submitVote"
+          data:
+            roomId: "{{ ROOM_ID }}"
+            userId: "{{ userId }}"
+            value: "5"
+      - think: 3
+      # Zostawiamy klienta podłączonego – symuluje obecność na sesji

--- a/logger.js
+++ b/logger.js
@@ -1,0 +1,77 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const LOG_DIR = process.env.LOG_DIR || path.join(process.cwd(), 'logs');
+const LOG_LEVEL = (process.env.LOG_LEVEL || 'info').toLowerCase();
+const LOG_TO_CONSOLE = (process.env.LOG_TO_CONSOLE ?? 'true') === 'true';
+
+function ensureDirSync(dir) {
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+  } catch {}
+}
+
+ensureDirSync(LOG_DIR);
+
+const appLogPath = path.join(LOG_DIR, 'app.log');
+const errLogPath = path.join(LOG_DIR, 'error.log');
+
+const appStream = fs.createWriteStream(appLogPath, { flags: 'a' });
+const errStream = fs.createWriteStream(errLogPath, { flags: 'a' });
+
+const levels = { error: 0, warn: 1, info: 2, debug: 3 };
+
+function serializeMeta(meta) {
+  if (!meta) return '';
+  try {
+    return ' ' + JSON.stringify(meta);
+  } catch {
+    return ' ' + String(meta);
+  }
+}
+
+function write(stream, line) {
+  try {
+    stream.write(line + '\n');
+  } catch {}
+}
+
+function log(level, message, meta) {
+  const ts = new Date().toISOString();
+  const line = `${ts} ${level.toUpperCase()} ${message}${serializeMeta(meta)}`;
+  // stdout/stderr
+  if (level === 'error') {
+    if (LOG_TO_CONSOLE) console.error(line);
+    write(errStream, line);
+  } else if (level === 'warn') {
+    if (LOG_TO_CONSOLE) console.warn(line);
+    write(appStream, line);
+  } else {
+    if (LOG_TO_CONSOLE) console.log(line);
+    write(appStream, line);
+  }
+}
+
+function shouldLog(level) {
+  return levels[level] <= levels[LOG_LEVEL];
+}
+
+export const logger = {
+  error: (msg, meta) => { if (shouldLog('error')) log('error', msg, meta); },
+  warn:  (msg, meta) => { if (shouldLog('warn'))  log('warn',  msg, meta); },
+  info:  (msg, meta) => { if (shouldLog('info'))  log('info',  msg, meta); },
+  debug: (msg, meta) => { if (shouldLog('debug')) log('debug', msg, meta); },
+};
+
+// Global handlers to catch unexpected crashes
+process.on('uncaughtException', (err) => {
+  logger.error('uncaughtException', { message: err?.message, stack: err?.stack });
+});
+
+process.on('unhandledRejection', (reason) => {
+  logger.error('unhandledRejection', { reason: reason instanceof Error ? { message: reason.message, stack: reason.stack } : reason });
+});


### PR DESCRIPTION
…ry profile, multi-stage Docker build, test gate in CI; fix ack crash

Server/Logging:
- Add structured logger (app.log, error.log) with levels (LOG_LEVEL) and LOG_TO_CONSOLE switch
- Replace console.* with logger.* across Socket.IO handlers and server startup
- Add HTTP access log middleware for /api (excludes /api/health):
  - errors-only by default (ACCESS_LOG_ERRORS_ONLY)
  - sampling support (ACCESS_LOG_SAMPLE)
  - slow requests threshold (ACCESS_LOG_SLOW_MS)
  - TRUST_PROXY support for correct client IP behind reverse proxies
- Fix “callback is not a function” crash by normalizing Socket.IO acks in createRoom/joinRoom/rejoinRoom

Docker:
- Rework Dockerfile to a secure multi-stage build (deps → builder → prod-deps → final), final runs as non-root
- Final image contains only production dependencies; add curl and healthcheck
- Include build-time metadata (BUILD_DATE, VCS_REF, VERSION, REPO_URL)
- Copy logger.js into final image for persistent logging
- Disable husky during container builds; prod-deps uses npm ci --omit=dev --ignore-scripts
- Introduce a low-memory build profile (ARG LOW_MEMORY=true) with sane defaults:
  - NODE_OPTIONS=--max-old-space-size=128, UV_THREADPOOL_SIZE=1, NODE_NO_WARNINGS=1
  - LOG_LEVEL=warn, LOG_TO_CONSOLE=false
  - ACCESS_LOG_ENABLED=true, ACCESS_LOG_ERRORS_ONLY=true, ACCESS_LOG_SAMPLE=10, ACCESS_LOG_SLOW_MS=0

CI (GitHub Actions):
- Add a test gate (npm ci, npm test) before building/pushing images
- Use Buildx with GitHub Actions cache (type=gha); push only to Docker Hub (remove GHCR)
- Tagging scheme: master and v* releases → latest; any branch → branch-name tag; semver for releases
- Add a second build (low-memory) with LOW_MEMORY=true:
  - Tags: krzprzybyla/poker-planning:lowmem and krzprzybyla/poker-planning:-lowmem
- Guard: build low-memory variant only on master or tag releases (v*)

Tooling/Quality:
- Add artillery-sio.yml (Socket.IO performance test scenario)
- Provide logrotate example for host (/var/log/poker-planning, weekly, rotate 12, copytruncate)
- ESLint: migrate .eslintrc.js → .cjs; add overrides for node/tests; reduce false positives
- TypeScript: enable esModuleInterop; export HealthStatus for proper typing in HealthIndicator

Runtime tips:
- Persist logs on host: -v /var/log/poker-planning:/logs -e LOG_DIR=/logs
- For constrained hosts (<=256MB RAM), use the low-memory image tags
- Correct port mapping: -p 80:3000 (container listens on 3000)